### PR TITLE
add task_5_output.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ dmypy.json
 
 # outputs
 **outputs*
+task_5_output.txt


### PR DESCRIPTION
I add task_5_output.txt in order to prevent unnecessary file change after test task_5.